### PR TITLE
Changes to allow 64-bit building

### DIFF
--- a/AlphaSync/AlphaSync.xcodeproj/project.pbxproj
+++ b/AlphaSync/AlphaSync.xcodeproj/project.pbxproj
@@ -424,7 +424,6 @@
 				8D1107290486CEB800E47090 /* Resources */,
 				8D11072C0486CEB800E47090 /* Sources */,
 				8D11072E0486CEB800E47090 /* Frameworks */,
-				4DDA9F92180F160A00BA274B /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -444,7 +443,6 @@
 				A95EFA5E0F17C94B00E1BDA9 /* Resources */,
 				A95EFA5F0F17C94B00E1BDA9 /* Sources */,
 				A95EFA600F17C94B00E1BDA9 /* Frameworks */,
-				4DDA9F91180F157800BA274B /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -468,6 +466,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* AlphaSync */;
@@ -521,35 +520,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		4DDA9F91180F157800BA274B /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Apply codesigning here rather than in the project (so that a SHA1 hash can be used as the identity).\nif [ ${CONFIGURATION} != \"Debug\" ] ; then\n  echo \"Stripping release build\"\n  /usr/bin/strip \"${BUILT_PRODUCTS_DIR}/${EXECUTABLE_PATH}\"\nfi\n\necho \"Applying app codesigning ${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}\"\n/usr/bin/codesign --force --sign \"0ce5fa2ff1f7e47a85df62f2ab16f943a213b85d\" \"${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}\"\n";
-		};
-		4DDA9F92180F160A00BA274B /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Apply codesigning here rather than in the project (so that a SHA1 hash can be used as the identity).\nif [ ${CONFIGURATION} != \"Debug\" ] ; then\n  echo \"Stripping release build\"\n  /usr/bin/strip \"${BUILT_PRODUCTS_DIR}/${EXECUTABLE_PATH}\"\nfi\n\necho \"Applying app codesigning ${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}\"\n/usr/bin/codesign --force --sign \"0ce5fa2ff1f7e47a85df62f2ab16f943a213b85d\" \"${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}\"\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		4D9630860F1D15A80018CDAA /* Sources */ = {
@@ -661,7 +631,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_MODEL_TUNING = G5;
@@ -678,7 +648,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_MODEL_TUNING = G5;
@@ -694,7 +664,7 @@
 		A95EFA660F17C94B00E1BDA9 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
@@ -718,7 +688,7 @@
 		A95EFA670F17C94B00E1BDA9 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				COPY_PHASE_STRIP = NO;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
 				GCC_MODEL_TUNING = G5;
@@ -740,8 +710,9 @@
 		C01FCF4B08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				COPY_PHASE_STRIP = NO;
+				DEVELOPMENT_TEAM = "";
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_MODEL_TUNING = G5;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -749,6 +720,7 @@
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				PRODUCT_NAME = AlphaSync;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				WRAPPER_EXTENSION = app;
 				ZERO_LINK = YES;
 			};
@@ -757,13 +729,15 @@
 		C01FCF4C08A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
+				DEVELOPMENT_TEAM = "";
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
 				GCC_MODEL_TUNING = G5;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				PRODUCT_NAME = AlphaSync;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
@@ -771,7 +745,8 @@
 		C01FCF4F08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = YES;
 				CODE_SIGN_IDENTITY = "";
 				COPY_PHASE_STRIP = NO;
@@ -799,7 +774,7 @@
 				GCC_WARN_UNUSED_PARAMETER = YES;
 				GCC_WARN_UNUSED_VALUE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.5;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_LINK_ESSENTIAL_SYMBOLS = NO;
 				STRIP_INSTALLED_PRODUCT = NO;
 			};
@@ -808,7 +783,8 @@
 		C01FCF5008A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = YES;
 				CODE_SIGN_IDENTITY = "";
 				COPY_PHASE_STRIP = NO;
@@ -836,7 +812,7 @@
 				GCC_WARN_UNUSED_PARAMETER = YES;
 				GCC_WARN_UNUSED_VALUE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.5;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_LINK_ESSENTIAL_SYMBOLS = NO;
 				STRIP_INSTALLED_PRODUCT = NO;
 			};

--- a/AlphaSync/AlphaSync.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/AlphaSync/AlphaSync.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/AlphaSync/Application/ASApplicationContoller.mm
+++ b/AlphaSync/Application/ASApplicationContoller.mm
@@ -134,7 +134,7 @@ static const NSInteger kMenuItemTagBackup   = 100;
 - (void)awakeFromNib
 {
     [outletMainWindow setDelegate:self];
-    [NSApp setDelegate:self];
+//s    [NSApp setDelegate:self];
 
     NSBundle* bundle = [NSBundle mainBundle];
     iconDisconnected = [[NSImage alloc] initWithContentsOfFile:[bundle pathForResource:@"icon-status-clear" ofType:@"pdf"]];

--- a/AlphaSync/Application/ASApplicationContoller.mm
+++ b/AlphaSync/Application/ASApplicationContoller.mm
@@ -134,7 +134,7 @@ static const NSInteger kMenuItemTagBackup   = 100;
 - (void)awakeFromNib
 {
     [outletMainWindow setDelegate:self];
-//s    [NSApp setDelegate:self];
+//    [NSApp setDelegate:self];
 
     NSBundle* bundle = [NSBundle mainBundle];
     iconDisconnected = [[NSImage alloc] initWithContentsOfFile:[bundle pathForResource:@"icon-status-clear" ofType:@"pdf"]];


### PR DESCRIPTION
All except one change are just wrangling Xcode Project Settings.

1. Set ARCHS = "$(ARCHS_STANDARD)" which today means 64-bit, for all Targets
2. Set ALWAYS_SEARCH_USER_PATHS = NO, for all Targets
3. Set MACOSX_DEPLOYMENT_TARGET = 10.9, for all Targets
4. Delete code-signing Build Phase, for both AlphaSync and AlphaSyncLauncher
5. Comment out one unecessary line that was throwing an error, only in AlphaSync

This builds with the current (at time of writing) Xcode 11.3, targeting macOS 10.9 (project was historically set to target 10.5 but that was removed from Xcode a long, long time ago)